### PR TITLE
refactor(getSerializedData): BREAKING CHANGE move serialization to poller and cache the results. GetSerializedData method added to Fetcher Interface

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -48,7 +48,7 @@ type Cache struct {
 	SerializedData string
 }
 
-// SplitCachePreload does something
+// SplitCachePreload contains the split/segment data from split.io
 type SplitCachePreload struct {
 	Since              int64
 	UsingSegmentsCount int
@@ -115,7 +115,7 @@ func (poller *Poller) GetSplitData() SplitData {
 	return (*(*Cache)(atomic.LoadPointer(&poller.cache))).SplitData
 }
 
-// GetSerializedData returns split data cache results
+// GetSerializedData returns serialized data cache results
 func (poller *Poller) GetSerializedData() string {
 	return (*(*Cache)(atomic.LoadPointer(&poller.cache))).SerializedData
 }

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -97,11 +97,8 @@ func (poller *Poller) pollForChanges() {
 		Segments:           segments,
 		UsingSegmentsCount: usingSegmentsCount,
 	}
-	serializedData, err := generateSerializedData(splitData)
-	if err != nil {
-		poller.Error <- err
-		return
-	}
+	serializedData := generateSerializedData(splitData)
+
 	updatedCache := Cache{
 		SplitData:      splitData,
 		SerializedData: serializedData,
@@ -147,9 +144,9 @@ func (poller *Poller) jobs() {
 
 // generateSerializedData takes SplitData and converts generates a script tag
 // that saves the SplitData info do the window object of the browser
-func generateSerializedData(splitData SplitData) (string, error) {
+func generateSerializedData(splitData SplitData) string {
 	if reflect.DeepEqual(splitData, SplitData{}) {
-		return emptyCacheLoggingScript, nil
+		return emptyCacheLoggingScript
 	}
 	splitsData := map[string]string{}
 
@@ -159,10 +156,7 @@ func generateSerializedData(splitData SplitData) (string, error) {
 		splitsData[split.Name] = string(marshalledSplit)
 	}
 
-	marshalledSplits, err := json.Marshal(splitsData)
-	if err != nil {
-		return "", err
-	}
+	marshalledSplits, _ := json.Marshal(splitsData)
 
 	segmentsData := map[string]string{}
 
@@ -172,12 +166,9 @@ func generateSerializedData(splitData SplitData) (string, error) {
 		segmentsData[segment.Name] = string(marshalledSegment)
 	}
 
-	marshalledSegments, err := json.Marshal(segmentsData)
-	if err != nil {
-		return "", err
-	}
+	marshalledSegments, _ := json.Marshal(segmentsData)
 
 	splitCachePreload := &SplitCachePreload{splitData.Since, splitData.UsingSegmentsCount, string(marshalledSplits), string(marshalledSegments)}
 
-	return fmt.Sprintf(formattedLoggingScript, splitCachePreload.SplitsData, splitCachePreload.Since, splitCachePreload.SegmentsData, splitCachePreload.UsingSegmentsCount), nil
+	return fmt.Sprintf(formattedLoggingScript, splitCachePreload.SplitsData, splitCachePreload.Since, splitCachePreload.SegmentsData, splitCachePreload.UsingSegmentsCount)
 }

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -143,7 +143,7 @@ func (poller *Poller) jobs() {
 }
 
 // generateSerializedData takes SplitData and generates a script tag
-// that saves the SplitData info do the window object of the browser
+// that saves the SplitData info to the window object of the browser
 func generateSerializedData(splitData SplitData) string {
 	if reflect.DeepEqual(splitData, SplitData{}) {
 		return emptyCacheLoggingScript

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -34,6 +34,12 @@ type Poller struct {
 	cache              unsafe.Pointer
 }
 
+// Cache contains raw split data as well as the data in serialized format
+type Cache struct {
+	SplitData
+	SerializedData string
+}
+
 // SplitData contains Splits and Segments which is supposed to be updated periodically
 type SplitData struct {
 	Splits             map[string]dtos.SplitDTO
@@ -42,13 +48,7 @@ type SplitData struct {
 	UsingSegmentsCount int
 }
 
-// Cache contains raw split data as well as the data in serialized format
-type Cache struct {
-	SplitData
-	SerializedData string
-}
-
-// SplitCachePreload contains the split/segment data from split.io
+// SplitCachePreload contains the same information as SplitData but in string format
 type SplitCachePreload struct {
 	Since              int64
 	UsingSegmentsCount int
@@ -145,6 +145,8 @@ func (poller *Poller) jobs() {
 	}
 }
 
+// generateSerializedData takes SplitData and converts generates a script tag
+// that saves the SplitData info do the window object of the browser
 func generateSerializedData(splitData SplitData) (string, error) {
 	if reflect.DeepEqual(splitData, SplitData{}) {
 		return emptyCacheLoggingScript, nil

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -1,6 +1,9 @@
 package poller
 
 import (
+	"encoding/json"
+	"fmt"
+	"reflect"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -9,11 +12,16 @@ import (
 	"github.com/splitio/go-client/splitio/service/dtos"
 )
 
+const emptyCacheLoggingScript = `<script>window.__splitCachePreload = {}</script>`
+
+const formattedLoggingScript = `<script>window.__splitCachePreload = { splitsData: %v, since: %v, segmentsData: %v, usingSegmentsCount: %v }</script>`
+
 // Fetcher is an interface contains GetSplitData, Start and Stop functions
 type Fetcher interface {
 	Start()
 	Stop()
 	GetSplitData() SplitData
+	GetSerializedData() string
 }
 
 // Poller implements Fetcher and contains cache pointer, splitio, and required info to interact with aplitio api
@@ -34,6 +42,20 @@ type SplitData struct {
 	UsingSegmentsCount int
 }
 
+// Cache contains raw split data as well as the data in serialized format
+type Cache struct {
+	SplitData
+	SerializedData string
+}
+
+// SplitCachePreload does something
+type SplitCachePreload struct {
+	Since              int64
+	UsingSegmentsCount int
+	SplitsData         string
+	SegmentsData       string
+}
+
 // NewPoller returns a new Poller
 func NewPoller(splitioAPIKey string, pollingRateSeconds int, serializeSegments bool, splitio api.Splitio) *Poller {
 	if pollingRateSeconds == 0 {
@@ -42,7 +64,11 @@ func NewPoller(splitioAPIKey string, pollingRateSeconds int, serializeSegments b
 	if splitio == nil {
 		splitio = api.NewSplitioAPIBinding(splitioAPIKey, "")
 	}
-	return &Poller{make(chan error), splitio, pollingRateSeconds, serializeSegments, make(chan bool), unsafe.Pointer(&SplitData{})}
+	emptyCache := Cache{
+		SplitData:      SplitData{},
+		SerializedData: emptyCacheLoggingScript,
+	}
+	return &Poller{make(chan error), splitio, pollingRateSeconds, serializeSegments, make(chan bool), unsafe.Pointer(&emptyCache)}
 }
 
 // pollForChanges updates the Cache with latest splits and segment
@@ -65,19 +91,33 @@ func (poller *Poller) pollForChanges() {
 	}
 
 	// Update Cache
-	updatedCache := SplitData{
+	splitData := SplitData{
 		Splits:             splits,
 		Since:              since,
 		Segments:           segments,
 		UsingSegmentsCount: usingSegmentsCount,
 	}
+	serializedData, err := generateSerializedData(splitData)
+	if err != nil {
+		poller.Error <- err
+		return
+	}
+	updatedCache := Cache{
+		SplitData:      splitData,
+		SerializedData: serializedData,
+	}
 	atomic.StorePointer(&poller.cache, unsafe.Pointer(&updatedCache))
 
 }
 
-// GetSplitData returns cache results of SplitData
+// GetSplitData returns split data cache results
 func (poller *Poller) GetSplitData() SplitData {
-	return *(*SplitData)(atomic.LoadPointer(&poller.cache))
+	return (*(*Cache)(atomic.LoadPointer(&poller.cache))).SplitData
+}
+
+// GetSerializedData returns split data cache results
+func (poller *Poller) GetSerializedData() string {
+	return (*(*Cache)(atomic.LoadPointer(&poller.cache))).SerializedData
 }
 
 // Start creates a goroutine and keep tracking until it stops
@@ -103,4 +143,39 @@ func (poller *Poller) jobs() {
 			poller.pollForChanges()
 		}
 	}
+}
+
+func generateSerializedData(splitData SplitData) (string, error) {
+	if reflect.DeepEqual(splitData, SplitData{}) {
+		return emptyCacheLoggingScript, nil
+	}
+	splitsData := map[string]string{}
+
+	// Serialize values for splits
+	for _, split := range splitData.Splits {
+		marshalledSplit, _ := json.Marshal(split)
+		splitsData[split.Name] = string(marshalledSplit)
+	}
+
+	marshalledSplits, err := json.Marshal(splitsData)
+	if err != nil {
+		return "", err
+	}
+
+	segmentsData := map[string]string{}
+
+	// Serialize values for segments
+	for _, segment := range splitData.Segments {
+		marshalledSegment, _ := json.Marshal(segment)
+		segmentsData[segment.Name] = string(marshalledSegment)
+	}
+
+	marshalledSegments, err := json.Marshal(segmentsData)
+	if err != nil {
+		return "", err
+	}
+
+	splitCachePreload := &SplitCachePreload{splitData.Since, splitData.UsingSegmentsCount, string(marshalledSplits), string(marshalledSegments)}
+
+	return fmt.Sprintf(formattedLoggingScript, splitCachePreload.SplitsData, splitCachePreload.Since, splitCachePreload.SegmentsData, splitCachePreload.UsingSegmentsCount), nil
 }

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -142,7 +142,7 @@ func (poller *Poller) jobs() {
 	}
 }
 
-// generateSerializedData takes SplitData and converts generates a script tag
+// generateSerializedData takes SplitData and generates a script tag
 // that saves the SplitData info do the window object of the browser
 func generateSerializedData(splitData SplitData) string {
 	if reflect.DeepEqual(splitData, SplitData{}) {

--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -181,18 +181,23 @@ func TestJobsCanRunTwiceAfterStop(t *testing.T) {
 
 	// First loop
 	cacheBeforeStart := result.GetSplitData()
+	serializedCacheBeforeStart := result.GetSerializedData()
 	assert.Equal(t, cacheBeforeStart, SplitData{})
 	assert.Equal(t, cacheBeforeStart.Since, int64(0))
 	assert.Equal(t, cacheBeforeStart.UsingSegmentsCount, 0)
+	assert.Equal(t, serializedCacheBeforeStart, emptyCacheLoggingScript)
 	go result.jobs()
 	time.Sleep(3 * time.Second)
 
 	// assert loop calls function so cache is updated
 	cacheAfterStart := result.GetSplitData()
+	serializedCacheAfterStart := result.GetSerializedData()
 	assert.True(t, cacheAfterStart.Since > 0)
 	assert.True(t, cacheAfterStart.UsingSegmentsCount > 0)
 	assert.Equal(t, cacheAfterStart.Splits["mock-split"].Name, "mock-split")
 	assert.Equal(t, cacheAfterStart.Segments["mock-segment"].Name, "mock-segment")
+	expectedSerializedScript, _ := generateSerializedData(cacheAfterStart)
+	assert.Equal(t, serializedCacheAfterStart, expectedSerializedScript)
 	result.Stop()
 
 	firstSince := result.GetSplitData().Since
@@ -287,18 +292,22 @@ func TestJobsKeepRunningAfterGettingError(t *testing.T) {
 
 	// first loop
 	cacheBeforeStart := result.GetSplitData()
+	serializedCacheBeforeStart := result.GetSerializedData()
 	assert.Equal(t, cacheBeforeStart, SplitData{})
 	assert.Equal(t, cacheBeforeStart.Since, int64(0))
 	assert.Equal(t, cacheBeforeStart.UsingSegmentsCount, 0)
+	assert.Equal(t, serializedCacheBeforeStart, emptyCacheLoggingScript)
 	go result.jobs()
 	err = <-result.Error
 	if err != nil {
 		hasErr = true
 	}
 	cacheAfterError := result.GetSplitData()
+	serializedCacheAfterError := result.GetSerializedData()
 	assert.Equal(t, cacheAfterError, SplitData{})
 	assert.Equal(t, cacheAfterError.Since, int64(0))
 	assert.Equal(t, cacheAfterError.UsingSegmentsCount, 0)
+	assert.Equal(t, serializedCacheAfterError, emptyCacheLoggingScript)
 	assert.True(t, hasErr)
 	assert.EqualError(t, err, "Error from splitio API when getting splits")
 
@@ -307,9 +316,55 @@ func TestJobsKeepRunningAfterGettingError(t *testing.T) {
 	mockSplitioDataGetter.getSegmentValid = true
 	time.Sleep(5 * time.Second)
 	cacheSecondRound := result.GetSplitData()
+	serializedCacheSecondRound := result.GetSerializedData()
 	assert.True(t, cacheSecondRound.Since > 0)
 	assert.True(t, cacheSecondRound.UsingSegmentsCount > 0)
 	assert.Equal(t, cacheSecondRound.Splits["mock-split"].Name, "mock-split")
 	assert.Equal(t, cacheSecondRound.Segments["mock-segment"].Name, "mock-segment")
+	expectedSerializedScript, _ := generateSerializedData(cacheSecondRound)
+	assert.Equal(t, serializedCacheSecondRound, expectedSerializedScript)
 	result.Stop()
+}
+
+func TestGenerateSerializedDataValid(t *testing.T) {
+	// Arrange
+	mockSplits := map[string]dtos.SplitDTO{
+		"mock-split-1": {
+			Name:   "mock-split-1",
+			Status: "mock-status-1",
+		},
+	}
+	mockSegments := map[string]dtos.SegmentChangesDTO{
+		"mock-segment-1": {
+			Name:  "mock-segment-1",
+			Added: []string{"foo", "bar"},
+			Since: 20,
+			Till:  20,
+		},
+	}
+	mockSplitData := SplitData{
+		Splits:             mockSplits,
+		Since:              1,
+		Segments:           mockSegments,
+		UsingSegmentsCount: 2,
+	}
+	// Act
+	result, err := generateSerializedData(mockSplitData)
+
+	// Validate that returned logging script contains a valid SplitData
+	stringSplits := `{"mock-split-1":"{\"changeNumber\":0,\"trafficTypeName\":\"\",\"name\":\"mock-split-1\",\"trafficAllocation\":0,\"trafficAllocationSeed\":0,\"seed\":0,\"status\":\"mock-status-1\",\"killed\":false,\"defaultTreatment\":\"\",\"algo\":0,\"conditions\":null,\"configurations\":null}"}`
+	stringSegments := `{"mock-segment-1":"{\"name\":\"mock-segment-1\",\"added\":[\"foo\",\"bar\"],\"removed\":null,\"since\":20,\"till\":20}"}`
+	expectedLoggingScript := fmt.Sprintf(formattedLoggingScript, stringSplits, 1, stringSegments, 2)
+	assert.Equal(t, result, expectedLoggingScript)
+	assert.Nil(t, err)
+}
+
+func TestGenerateSerializedDataMarshalEmptyCache(t *testing.T) {
+	// Act
+	result, err := generateSerializedData(SplitData{})
+
+	// Validate that returned logging script contains a valid SplitData
+	expectedLoggingScript := fmt.Sprintf(emptyCacheLoggingScript)
+	assert.Equal(t, result, expectedLoggingScript)
+	assert.Nil(t, err)
 }

--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -196,7 +196,7 @@ func TestJobsCanRunTwiceAfterStop(t *testing.T) {
 	assert.True(t, cacheAfterStart.UsingSegmentsCount > 0)
 	assert.Equal(t, cacheAfterStart.Splits["mock-split"].Name, "mock-split")
 	assert.Equal(t, cacheAfterStart.Segments["mock-segment"].Name, "mock-segment")
-	expectedSerializedScript, _ := generateSerializedData(cacheAfterStart)
+	expectedSerializedScript := generateSerializedData(cacheAfterStart)
 	assert.Equal(t, serializedCacheAfterStart, expectedSerializedScript)
 	result.Stop()
 
@@ -321,7 +321,7 @@ func TestJobsKeepRunningAfterGettingError(t *testing.T) {
 	assert.True(t, cacheSecondRound.UsingSegmentsCount > 0)
 	assert.Equal(t, cacheSecondRound.Splits["mock-split"].Name, "mock-split")
 	assert.Equal(t, cacheSecondRound.Segments["mock-segment"].Name, "mock-segment")
-	expectedSerializedScript, _ := generateSerializedData(cacheSecondRound)
+	expectedSerializedScript := generateSerializedData(cacheSecondRound)
 	assert.Equal(t, serializedCacheSecondRound, expectedSerializedScript)
 	result.Stop()
 }
@@ -349,22 +349,29 @@ func TestGenerateSerializedDataValid(t *testing.T) {
 		UsingSegmentsCount: 2,
 	}
 	// Act
-	result, err := generateSerializedData(mockSplitData)
+	result := generateSerializedData(mockSplitData)
 
 	// Validate that returned logging script contains a valid SplitData
 	stringSplits := `{"mock-split-1":"{\"changeNumber\":0,\"trafficTypeName\":\"\",\"name\":\"mock-split-1\",\"trafficAllocation\":0,\"trafficAllocationSeed\":0,\"seed\":0,\"status\":\"mock-status-1\",\"killed\":false,\"defaultTreatment\":\"\",\"algo\":0,\"conditions\":null,\"configurations\":null}"}`
 	stringSegments := `{"mock-segment-1":"{\"name\":\"mock-segment-1\",\"added\":[\"foo\",\"bar\"],\"removed\":null,\"since\":20,\"till\":20}"}`
 	expectedLoggingScript := fmt.Sprintf(formattedLoggingScript, stringSplits, 1, stringSegments, 2)
 	assert.Equal(t, result, expectedLoggingScript)
-	assert.Nil(t, err)
 }
 
 func TestGenerateSerializedDataMarshalEmptyCache(t *testing.T) {
 	// Act
-	result, err := generateSerializedData(SplitData{})
+	result := generateSerializedData(SplitData{})
 
 	// Validate that returned logging script contains a valid SplitData
 	expectedLoggingScript := fmt.Sprintf(emptyCacheLoggingScript)
 	assert.Equal(t, result, expectedLoggingScript)
-	assert.Nil(t, err)
+}
+
+func TestGenerateSerializedDataSplitError(t *testing.T) {
+	// Act
+	result := generateSerializedData(SplitData{})
+
+	// Validate that returned logging script contains a valid SplitData
+	expectedLoggingScript := fmt.Sprintf(emptyCacheLoggingScript)
+	assert.Equal(t, result, expectedLoggingScript)
 }

--- a/scripts/coverage-check.sh
+++ b/scripts/coverage-check.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-THRESHOLD='97.3s'
+THRESHOLD='97.3'
 
 COVERAGE=$(go tool cover -func $1 | grep 'total:' | awk '{ print(substr($3, 1, length($3)-1)) }')
 PASSED=$(echo "${COVERAGE}>=${THRESHOLD}" | bc -l)

--- a/scripts/coverage-check.sh
+++ b/scripts/coverage-check.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-THRESHOLD='97.3'
+THRESHOLD='96.0'
 
 COVERAGE=$(go tool cover -func $1 | grep 'total:' | awk '{ print(substr($3, 1, length($3)-1)) }')
 PASSED=$(echo "${COVERAGE}>=${THRESHOLD}" | bc -l)

--- a/scripts/coverage-check.sh
+++ b/scripts/coverage-check.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-THRESHOLD='96.0'
+THRESHOLD='97.3s'
 
 COVERAGE=$(go tool cover -func $1 | grep 'total:' | awk '{ print(substr($3, 1, length($3)-1)) }')
 PASSED=$(echo "${COVERAGE}>=${THRESHOLD}" | bc -l)

--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -1,24 +1,8 @@
 package serializer
 
 import (
-	"encoding/json"
-	"fmt"
-	"reflect"
-
 	"github.com/godaddy/split-go-serializer/v2/poller"
 )
-
-const emptyCacheLoggingScript = `<script>window.__splitCachePreload = {}</script>`
-
-const formattedLoggingScript = `<script>window.__splitCachePreload = { splitsData: %v, since: %v, segmentsData: %v, usingSegmentsCount: %v }</script>`
-
-// SplitCachePreload does something
-type SplitCachePreload struct {
-	Since              int64
-	UsingSegmentsCount int
-	SplitsData         string
-	SegmentsData       string
-}
 
 // Serializer contains poller
 type Serializer struct {
@@ -32,37 +16,6 @@ func NewSerializer(poller poller.Fetcher) *Serializer {
 
 // GetSerializedData serializes split and segment data into strings
 func (serializer *Serializer) GetSerializedData() (string, error) {
-	latestData := serializer.poller.GetSplitData()
-	if reflect.DeepEqual(latestData, poller.SplitData{}) {
-		return emptyCacheLoggingScript, nil
-	}
-	splitsData := map[string]string{}
-
-	// Serialize values for splits
-	for _, split := range latestData.Splits {
-		marshalledSplit, _ := json.Marshal(split)
-		splitsData[split.Name] = string(marshalledSplit)
-	}
-
-	marshalledSplits, err := json.Marshal(splitsData)
-	if err != nil {
-		return "", err
-	}
-
-	segmentsData := map[string]string{}
-
-	// Serialize values for segments
-	for _, segment := range latestData.Segments {
-		marshalledSegment, _ := json.Marshal(segment)
-		segmentsData[segment.Name] = string(marshalledSegment)
-	}
-
-	marshalledSegments, err := json.Marshal(segmentsData)
-	if err != nil {
-		return "", err
-	}
-
-	splitCachePreload := &SplitCachePreload{latestData.Since, latestData.UsingSegmentsCount, string(marshalledSplits), string(marshalledSegments)}
-
-	return fmt.Sprintf(formattedLoggingScript, splitCachePreload.SplitsData, splitCachePreload.Since, splitCachePreload.SegmentsData, splitCachePreload.UsingSegmentsCount), nil
+	serializedData := serializer.poller.GetSerializedData()
+	return serializedData, nil
 }

--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -14,7 +14,7 @@ func NewSerializer(poller poller.Fetcher) *Serializer {
 	return &Serializer{poller}
 }
 
-// GetSerializedData serializes split and segment data into strings
+// GetSerializedData retrieves serialized data from the cache
 func (serializer *Serializer) GetSerializedData() (string, error) {
 	serializedData := serializer.poller.GetSerializedData()
 	return serializedData, nil

--- a/serializer/serializer_test.go
+++ b/serializer/serializer_test.go
@@ -1,7 +1,6 @@
 package serializer
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/godaddy/split-go-serializer/v2/poller"
@@ -22,6 +21,10 @@ func (fetcher *mockFetcher) Start() {
 }
 
 func (fetcher *mockFetcher) Stop() {
+}
+
+func (fetcher *mockFetcher) GetSerializedData() string {
+	return "foo"
 }
 
 func (fetcher *mockFetcher) GetSplitData() poller.SplitData {
@@ -73,23 +76,8 @@ func TestGetSerializedDataValid(t *testing.T) {
 	// Act
 	result, err := serializer.GetSerializedData()
 
-	// Validate that returned logging script contains a valid SplitData
-	stringSplits := `{"mock-split-1":"{\"changeNumber\":0,\"trafficTypeName\":\"\",\"name\":\"mock-split-1\",\"trafficAllocation\":0,\"trafficAllocationSeed\":0,\"seed\":0,\"status\":\"mock-status-1\",\"killed\":false,\"defaultTreatment\":\"\",\"algo\":0,\"conditions\":null,\"configurations\":null}"}`
-	stringSegments := `{"mock-segment-1":"{\"name\":\"mock-segment-1\",\"added\":[\"foo\",\"bar\"],\"removed\":null,\"since\":20,\"till\":20}"}`
-	expectedLoggingScript := fmt.Sprintf(formattedLoggingScript, stringSplits, 1, stringSegments, 2)
-	assert.Equal(t, result, expectedLoggingScript)
-	assert.Nil(t, err)
-}
-
-func TestGetSerializedDataMarshalEmptyCache(t *testing.T) {
-	// Arrange
-	serializer := NewSerializer(&mockFetcher{hasData: false})
-
-	// Act
-	result, err := serializer.GetSerializedData()
-
-	// Validate that returned logging script contains a valid SplitData
-	expectedLoggingScript := fmt.Sprintf(emptyCacheLoggingScript)
+	// Validate that returned logging script contains the string from poller cache
+	expectedLoggingScript := "foo"
 	assert.Equal(t, result, expectedLoggingScript)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
This change and https://jira.godaddy.com/browse/ML-1900 will both be breaking changes because they will change the Fetcher Interface. To reduce our number of versions and the hassle that goes along with it, I propose merging both into this https://github.com/godaddy/split-go-serializer/tree/v3 and then merging them into master together and doing a single version bump.