### PR TITLE
fix(generateSerializedData): correctly set segments-related data if splitNames is non-empty

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -186,10 +186,11 @@ func (poller *Poller) generateSerializedData(splitData SplitData, splitNames []s
 	}
 	splitNamesToSerializedData := map[string]string{}
 	splitsSubset := map[string]dtos.SplitDTO{}
+	serializingASubsetOfSplits := len(splitNames) > 0
 
 	// Serialize values for splits
 	for name, split := range splitData.Splits {
-		if len(splitNames) > 0 {
+		if serializingASubsetOfSplits {
 			index := sort.SearchStrings(splitNames, split.Name)
 			splitIsInSplitNames := index < len(splitNames) && splitNames[index] == split.Name
 			// if the split is not in the splitNames array, do not serialize the split
@@ -208,7 +209,7 @@ func (poller *Poller) generateSerializedData(splitData SplitData, splitNames []s
 	usingSegmentsCount := splitData.UsingSegmentsCount
 
 	// get segments and usingSegmentsCount for subset of splits
-	if len(splitNames) > 0 {
+	if serializingASubsetOfSplits {
 		err := error(nil)
 		binding := poller.splitio
 		segments, usingSegmentsCount, err = binding.GetSegmentsForSplits(splitsSubset)

--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -491,7 +491,7 @@ func TestGenerateSerializedDataWithNonEmptySplitNames(t *testing.T) {
 	assert.Equal(t, result, expectedLoggingScript)
 }
 
-func TestGenerateSerializedDataWithInvalidSegmentsReturnsEmptyScript(t *testing.T) {
+func TestGenerateSerializedDataWithNonEmptySplitNamesAndInvalidSegmentsReturnsEmptyScript(t *testing.T) {
 	// Arrange
 	getSegmentValid := false
 	poller := NewPoller(testKey, 1, serializeSegments,


### PR DESCRIPTION
Before this fix, if a non-empty `splitNames` is passed in, the serialized segments data and `usingSegmentsCount` will not be tailored to this subset of splits.