### PR TITLE
fix(Fetcher): update method to have a string list parameter

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -22,7 +22,7 @@ const formattedLoggingScript = `<script>window.__splitCachePreload = { splitsDat
 type Fetcher interface {
 	Start()
 	Stop()
-	GetSerializedData() string
+	GetSerializedData(splitNames []string) string
 }
 
 // Poller implements Fetcher and contains cache pointer, splitio, and required info to interact with aplitio api


### PR DESCRIPTION
This change makes the `Fetcher` interface abide by the format of the [`GetSerializedData`](https://github.com/godaddy/split-go-serializer/blob/4d5dff6e9a65cdb16b18a5301f3262ca6380b0e3/poller/poller.go#L115) method defined for the `Poller` struct.