### PR TITLE
SA1006: use print-style function instead (staticcheck)

### DIFF
--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -569,7 +569,7 @@ func TestGenerateSerializedDataMarshalEmptyCache(t *testing.T) {
 	result := poller.generateSerializedData(SplitData{}, []string{})
 
 	// Validate that returned logging script contains a valid SplitData
-	expectedLoggingScript := fmt.Sprintf(emptyCacheLoggingScript)
+	expectedLoggingScript := fmt.Sprint(emptyCacheLoggingScript)
 	assert.Equal(t, result, expectedLoggingScript)
 }
 
@@ -582,6 +582,6 @@ func TestGenerateSerializedDataSplitError(t *testing.T) {
 	result := poller.generateSerializedData(SplitData{}, []string{})
 
 	// Validate that returned logging script contains a valid SplitData
-	expectedLoggingScript := fmt.Sprintf(emptyCacheLoggingScript)
+	expectedLoggingScript := fmt.Sprint(emptyCacheLoggingScript)
 	assert.Equal(t, result, expectedLoggingScript)
 }


### PR DESCRIPTION
SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)